### PR TITLE
docs(readme): ecosystem links, n8n package pointer, roadmap freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Building a Taskade integration for another platform (n8n, Activepieces, Make, Pi
 - v1 REST API: `https://www.taskade.com/api/v1` — [spec](https://www.taskade.com/api/documentation/v1/json)
 - v2 Action API: `https://www.taskade.com/api/v2` — [spec](https://www.taskade.com/api/documentation/v2/json)
 
+## Packages
+
+- [`packages/n8n-nodes-taskade`](packages/n8n-nodes-taskade) — official n8n community node for Taskade, built in this repo
+
 ## Zapier app capabilities
 
 | Type | Key | What it does |
@@ -59,7 +63,13 @@ zapier logs --type=http --detailed
 
 ## Roadmap
 
-- Platform-agnostic operation manifest + per-platform codegen (n8n node, Activepieces piece rendered from one source)
+- Platform-agnostic operation manifest + per-platform codegen — the existing [n8n node](packages/n8n-nodes-taskade) and future targets (Activepieces, Make, Pipedream) rendered from one source
 - Portable event triggers once the public webhook-subscription API ships
 
 See the [Zapier Integration Guide](https://help.taskade.com/en/articles/8958540-zapier-integration) for end-user docs.
+
+## Related repos
+
+- [Taskade Docs](https://github.com/taskade/docs) — source for [docs.taskade.com](https://docs.taskade.com)
+- [Taskade MCP](https://github.com/taskade/mcp) — official MCP server ([`@taskade/mcp-server`](https://www.npmjs.com/package/@taskade/mcp-server) on npm)
+- [Taskade](https://github.com/taskade/taskade) — platform home, including the Genesis AI app builder

--- a/packages/n8n-nodes-taskade/README.md
+++ b/packages/n8n-nodes-taskade/README.md
@@ -18,7 +18,7 @@ Personal Access Token — create one at taskade.com → Settings → API (tokens
 
 ## Installation
 
-Self-hosted n8n: **Settings → Community Nodes → Install** → `n8n-nodes-taskade`.
+Self-hosted n8n: **Settings → Community Nodes → Install** → `n8n-nodes-taskade` (npm publish pending — follow this repo for the release).
 
 ## Development
 


### PR DESCRIPTION
## What

README-only changes, two files:

- **Root `README.md`**
  - New **Packages** section pointing to the in-repo n8n community node at [`packages/n8n-nodes-taskade`](packages/n8n-nodes-taskade) (relative link).
  - Roadmap freshness: the codegen bullet previously presented the n8n node as a *future* deliverable, but the package already lives in this repo — reworded so codegen now reads as letting the **existing** n8n node and future platform targets (Activepieces, Make, Pipedream) render from one manifest.
  - New **Related repos** footer: [Taskade Docs](https://github.com/taskade/docs) (source for docs.taskade.com), [Taskade MCP](https://github.com/taskade/mcp) (official MCP server, `@taskade/mcp-server` on npm), and [Taskade](https://github.com/taskade/taskade) (platform home — Genesis AI app builder).
- **`packages/n8n-nodes-taskade/README.md`**
  - The install section tells users to install `n8n-nodes-taskade` from npm, but the package is not yet published (verified npm E404). Added the note: *(npm publish pending — follow this repo for the release)* so nobody hits a dead install.

## Why

Taskade's public repos currently don't cross-link, so the org's link graph has dead ends: developers arriving here from the MCP registry, npm (`@taskade/mcp-server`), docs.taskade.com, or the awesome-list submissions can't discover the rest of the platform — and vice versa, nothing routes from this repo back to docs, MCP, or the platform home. This PR closes that loop from the integrations side and fixes the one stale roadmap claim plus the one misleading install instruction found while auditing.

For context on the platform these integrations plug into: Taskade Genesis is the AI app builder — one prompt generates a working app backed by your workspace, where projects become the database, AI agents the team, and automations the execution layer, with 100+ integrations and MCP support. Docs: https://docs.taskade.com

## Zero-regression verification

Checks actually run before pushing:

- [x] `curl -sL -o /dev/null -w "%{http_code}"` on every new/changed URL: `https://github.com/taskade/docs` → 200, `https://docs.taskade.com` → 200, `https://github.com/taskade/mcp` → 200, `https://github.com/taskade/taskade` → 200, existing `https://help.taskade.com/en/articles/8958540-zapier-integration` → 200
- [x] `https://www.npmjs.com/package/@taskade/mcp-server` → 403 to curl (npmjs.com Cloudflare bot blocking, including with a browser UA); package existence verified via registry API `https://registry.npmjs.org/@taskade/mcp-server` → 200 — the page link works in browsers
- [x] Relative link target exists: `packages/n8n-nodes-taskade/` present in repo; `https://github.com/taskade/integrations/tree/master/packages/n8n-nodes-taskade` → 200
- [x] `n8n-nodes-taskade` confirmed unpublished: `https://registry.npmjs.org/n8n-nodes-taskade` → 404 (backs the "publish pending" note)
- [x] Markdown tables untouched and pipe counts consistent per row (root capabilities table: 4 pipes × 14 rows; n8n operations table: 3 pipes × 5 rows)
- [x] `git diff` reviewed — only the intended lines changed (12 insertions, 2 deletions across the two READMEs); no other sections touched

cc @deanzaka @lxcid