### PR TITLE
fix(ci): skip native compiles in n8n publish workflow

### DIFF
--- a/.github/workflows/publish-n8n.yml
+++ b/.github/workflows/publish-n8n.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
-      - run: npm install
+      - run: npm install --ignore-scripts # types-only build; skip native compiles (isolated-vm)
       - run: npm run build
       - run: npm publish --provenance --access public
         env:


### PR DESCRIPTION
First publish run failed: `npm install` compiles `isolated-vm` (transitive native dep of `n8n-workflow`) and its C++ build breaks on the runner. The package build only needs TypeScript types — `--ignore-scripts` skips all native compiles. Verified locally that `tsc` needs no built natives.